### PR TITLE
Roger's modifications

### DIFF
--- a/instruqt-tracks/boundary-ssh-and-database/configure-admin-roles/check-boundary-controller
+++ b/instruqt-tracks/boundary-ssh-and-database/configure-admin-roles/check-boundary-controller
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
-# Check that the org scope admin role was created
+# Check that the global scope admin role was created
 GLOBAL_ADMIN_ROLE_NAME=$(boundary roles list \
 	-recovery-config /etc/boundary.d/recovery.hcl \
 	-scope-id global \
@@ -11,10 +11,11 @@ if [ "$GLOBAL_ADMIN_ROLE_NAME" != "global_admin" ]; then
     exit 1
 fi
 
+# Check that the org scope admin role was created
 ORG_ADMIN_ROLE_NAME=$(boundary roles list \
 	-recovery-config /etc/boundary.d/recovery.hcl \
-	-scope-id global \
-	-format json | jq -r ".items[2].name")
+	-scope-id $ORG_SCOPE_ID \
+	-format json | jq -r ".items[1].name")
 
 if [ "$ORG_ADMIN_ROLE_NAME" != "org_admin" ]; then
     fail-message "You did not create the org_admin role."
@@ -24,11 +25,11 @@ fi
 # Check that the project scope admin role was created
 PROJECT_ADMIN_ROLE_NAME=$(boundary roles list \
 	-recovery-config /etc/boundary.d/recovery.hcl \
-	-scope-id $ORG_SCOPE_ID \
-	-format json | jq -r ".items[1].name")
+	-scope-id $PROJECT_SCOPE_ID \
+	-format json | jq -r ".items[0].name")
 
 if [ "$PROJECT_ADMIN_ROLE_NAME" != "project_admin" ]; then
-    fail-message "You did not create the org_admin role."
+    fail-message "You did not create the project_admin role."
     exit 1
 fi
 

--- a/instruqt-tracks/boundary-ssh-and-database/configure-and-connect-to-postgres-with-tcp/check-boundary-controller
+++ b/instruqt-tracks/boundary-ssh-and-database/configure-and-connect-to-postgres-with-tcp/check-boundary-controller
@@ -5,7 +5,7 @@ POSTGRES_HOST_NAME=$(boundary hosts list \
 	-host-catalog-id $PROJECT_HOST_CATALOG_ID \
 	-format json | jq -r ".items[-1].name")
 
-if [ "$POSTGRES_HOST_NAME" != "postgres-host" ]; then
+if [ "$POSTGRES_HOST_NAME" != "postgres" ]; then
     fail-message "You did not create the Postgres host."
 	exit 1
 fi
@@ -13,7 +13,7 @@ fi
 # Check that the host set was created.
 POSTGRES_HOST_SET_NAME=$(boundary host-sets list \
 	-host-catalog-id $PROJECT_HOST_CATALOG_ID \
-	-format json | jq -r ".items[-1].name")
+	-format json | jq -r ".items[1].name")
 
 if [ "$POSTGRES_HOST_SET_NAME" != "test-postgres-host-set" ]; then
     fail-message "You did not create the Postgres host set."
@@ -23,7 +23,7 @@ fi
 # Check that the target was created.
 POSTGRES_TARGET_NAME=$(boundary targets list \
 	-scope-id $PROJECT_SCOPE_ID \
-	-format json | jq -r ".items[-1].name")
+	-format json | jq -r ".items[1].name")
 
 if [ "$POSTGRES_TARGET_NAME" != "postgres-test-targets" ]; then
     fail-message "You did not create the Postgres Target."

--- a/instruqt-tracks/boundary-ssh-and-database/configure-and-connect-to-postgres-with-tcp/solve-boundary-controller
+++ b/instruqt-tracks/boundary-ssh-and-database/configure-and-connect-to-postgres-with-tcp/solve-boundary-controller
@@ -4,7 +4,7 @@
 # Create the Postgres Host, store the ID in the environment
 ###
 export POSTGRES_HOST_ID=$(boundary hosts create static \
-	-name postgres-host \
+	-name postgres \
 	-description "Postgres host" \
 	-address "boundary-worker" \
 	-host-catalog-id $PROJECT_HOST_CATALOG_ID \
@@ -25,6 +25,7 @@ export POSTGRES_HOST_SET_ID=$(boundary host-sets create static \
 echo "Postgres Host Set ID:" $POSTGRES_HOST_SET_ID
 echo "export POSTGRES_HOST_SET_ID=$POSTGRES_HOST_SET_ID" >> ~/.bashrc
 
+# Add host to host-set
 boundary host-sets add-hosts \
 	-id $POSTGRES_HOST_SET_ID \
 	-host=$POSTGRES_HOST_ID
@@ -43,11 +44,13 @@ export POSTGRES_TARGET_ID=$(boundary targets create tcp \
 echo "Postgres Target ID:" $POSTGRES_TARGET_ID
 echo "export POSTGRES_TARGET_ID=$POSTGRES_TARGET_ID" >> ~/.bashrc
 
+# Add host-set to the target
 boundary targets add-host-sets \
 	-id $POSTGRES_TARGET_ID \
 	-host-set $POSTGRES_HOST_SET_ID
 
-# TODO: boundary connect postgres -target-id $POSTGRES_TARGET_ID -dbname postgres
- -username postgres -- -l
+# Connect to postgres
+export PGPASSWORD=postgres
+boundary connect postgres -target-id $POSTGRES_TARGET_ID -username postgres
 
 exit 0

--- a/instruqt-tracks/boundary-ssh-and-database/configure-and-connect-to-your-first-target-with-ssh/check-boundary-controller
+++ b/instruqt-tracks/boundary-ssh-and-database/configure-and-connect-to-your-first-target-with-ssh/check-boundary-controller
@@ -25,7 +25,7 @@ SSH_HOST_SET_NAME=$(boundary host-sets list \
 	-host-catalog-id $PROJECT_HOST_CATALOG_ID \
 	-format json | jq -r ".items[0].name")
 
-if [ "$SSH_HOST_SET_NAME" != "test-ssh-host-set" ]; then
+if [ "$SSH_HOST_SET_NAME" != "test-machines" ]; then
     fail-message "You did not create the SSH host set."
 	exit 1
 fi

--- a/instruqt-tracks/boundary-ssh-and-database/configure-and-connect-to-your-first-target-with-ssh/solve-boundary-controller
+++ b/instruqt-tracks/boundary-ssh-and-database/configure-and-connect-to-your-first-target-with-ssh/solve-boundary-controller
@@ -6,7 +6,7 @@
 export PROJECT_HOST_CATALOG_ID=$(boundary host-catalogs create static \
 	-scope-id $PROJECT_SCOPE_ID \
 	-name "HashiCups Web App" \
-	-description "For HashiCups App usage" \
+	-description "For HashiCups Web App usage" \
 	-format json | jq -r .item.id)
 
 echo "Host Catalog ID:" $PROJECT_HOST_CATALOG_ID
@@ -28,7 +28,7 @@ echo "export WORKER_HOST_ID=$WORKER_HOST_ID" >> ~/.bashrc
 # Create the SSH Host Set, store the ID in the environment
 ###
 export SSH_HOST_SET_ID=$(boundary host-sets create static \
-	-name "test-ssh-host-set" \
+	-name "test-machines" \
 	-description "Test machine host set" \
 	-host-catalog-id $PROJECT_HOST_CATALOG_ID \
 	-format json | jq -r .item.id)

--- a/instruqt-tracks/boundary-ssh-and-database/track.yml
+++ b/instruqt-tracks/boundary-ssh-and-database/track.yml
@@ -6,9 +6,9 @@ teaser: Learn how to take a blank canvas Boundary deployment and configure it fo
 description: |-
   In this track, you will take a blank canvas Boundary cluster, and learn how to get it ready for production. That
   includes configuring auth methods, accounts, users, groups, and roles. You will also learn how to manage targets,
-  access to those targets, and how to log in and connect to them. At the end, you will learn how to manage sessions
+  access those targets, and how to log in and connect to them. At the end, you will learn how to manage sessions
   with Boundary, and take a tour of the Boundary Admin UI.
-icon: https://storage.googleapis.com/instruqt-frontend/assets/hashicorp/tracks/boundary.png
+icon: https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/boundary.png
 tags:
 - boundary
 owner: hashicorp
@@ -29,8 +29,8 @@ challenges:
     contents: |-
       Boundary is a tool for managing identity-based access for modern, dynamic infrastructure. Just as infrastructure
       itself can be complex, at first glance Boundary can seem complex as well. As a result, it's helpful to understand
-      how Boundary organizes security principals and resources, as well as how it allows you define granular
-      permissions to those principals.
+      how Boundary organizes security principals and resources, as well as how it allows you to define granular
+      permissions for those principals.
 
       In this track, you will learn how to manage all the different principals and resources in Boundary, as well as
       how to leverage those resources to connect to a host via SSH, as well as a Postgres instance via TCP.
@@ -38,8 +38,8 @@ challenges:
     contents: |-
       In this challenge, you will learn about the following Boundary resources.
 
-      - *Scope*: Abstract permission boundary modeled as a container. A scope can contain scopes forming a tree.
-      - *Organization*: Top-level container (scope) which owns zero to many projects and zero to many authentication methods. An organization inherits from scope allowing it to own zero to many groups, roles, policies, targets, host catalogs or credential stores.
+      - *Scope*: Abstract permission boundary modeled as a container. A scope can contain other scopes forming a tree.
+      - *Organization*: Top-level container (scope) which owns zero to many projects and zero to many authentication methods. An organization inherits from the global scope allowing it to own zero to many groups, roles, policies, targets, host catalogs or credential stores.
       - *Project*: Child scope of an organization.
   - type: text
     contents: |-
@@ -52,7 +52,7 @@ challenges:
     contents: |-
       The Boundary cluster was initialized *without generated resources*...
 
-      What are generated resources? When you run `boundary dev` or boundary `database init`, Boundary automatically
+      What are generated resources? When you run `boundary dev` or `boundary database init`, Boundary automatically
       generates a number of resources to make getting started easier. Default scopes, auth methods, user, account, and
       targets are just some of the resources Boundary will generate unless you tell it not to.
   - type: text
@@ -80,7 +80,7 @@ challenges:
     You're going to specify a role for managing these scopes by selected users in a later challenge.
 
     In this track you will make use of a the [Recovery KMS Workflow](https://www.boundaryproject.io/docs/installing/no-gen-resources#recovery-kms-workflow).
-    This allows you to use a key specifid to "recover" Boundary, but you can also use it to authenticate to Boundary
+    This allows you to use a key specified to "recover" Boundary, but you can also use it to authenticate to Boundary
     and manage it as a "global" super user. This allows you to authenticate from the CLI or from Terraform in order to
     manage Boundary without any generated resources. The recovery block you will use is located at
     `/etc/boundary.d/recovery.hcl`.
@@ -210,7 +210,7 @@ challenges:
       contains accounts which link an individual user to a set of credentials and managed groups which groups accounts
       that satisfy criteria and can be used as principals in roles.
 
-      Auth methods can be defined at either a `global` or org scope.
+      Auth methods can be defined at either a `global` or `org` scope.
   assignment: |-
     Now that you have your org scope and project scope created, it's time to add your first auth method.
 
@@ -321,8 +321,8 @@ challenges:
       deleted: anonymous (`u_anon`), authenticate (`u_auth`), and recovery (`u_recovery`).
 
       In this challenge you will use `u_anon`, which represents users that are not authenticated with Boundary. This
-      is useful for providing permissions to users who are not logged in, and want to inspect certain endpoints in
-      Boundary to log in.
+      is useful for providing permissions to users who are not logged in and want to inspect certain endpoints in
+      Boundary that they could use to log in.
   - type: text
     contents: |-
       This is useful not only from the CLI, but the Boundary UI leverages the `u_anon` principal to display the scopes
@@ -338,7 +338,7 @@ challenges:
     to see the scopes or auth methods that you just created. This means the average user is completely left in the
     dark when trying to authenticate.
 
-    The first two roles you will created will allow anonymous (unauthenticated) users the ability to list scopes and
+    The first two roles you will create will allow anonymous (unauthenticated) users the ability to list scopes and
     their auth methods. Once you have created these two roles, you'll attach them to the `u_anon` principal, which
     will allow any user to discover how and where to log in.
 
@@ -348,7 +348,7 @@ challenges:
     ---
 
     First, open the Boundary UI tab. You should see a white screen. This is because currently, Boundary is configured
-    to not allow anonymous users the ability to see the scopes or the auth methods in boundary. To allow for users
+    to not allow anonymous users the ability to see the scopes or the auth methods in boundary. To allow users
     to see the auth methods in the `global` scope, you'll need to create an anonymous role in the `global` scope that
     can list the scopes, auth methods, and allow a user to see their account and update their password.
 
@@ -356,6 +356,7 @@ challenges:
 
     ```
     boundary roles create \
+      -recovery-config /etc/boundary.d/recovery.hcl \
       -scope-id global \
       -name global_anon_listing
     ```
@@ -1269,7 +1270,7 @@ challenges:
 
     Up until now, you've been leveraging the Recovery KMS Workflow to create the anonymous listing users, as well
     as the admin users. Since you now have admin users to leverage, you wil no longer need that workflow as long as
-    you are logged in as an admin user.
+    you are logged in as an admin user and have exported a Boundary token.
 
     ---
 
@@ -1285,7 +1286,7 @@ challenges:
     Scope information:
       ID:                    p_E5Hi8BQlJm
         Version:             1
-        Name:                HashiCups App
+        Name:                HashiCups Web App
         Authorized Actions:
           no-op
           read
@@ -1293,7 +1294,7 @@ challenges:
           delete
     ```
 
-    You should recognize the "HashiCups App" project scope you created in the previous challenge. Currently, there
+    You should recognize the "HashiCups Web App" project scope you created in the previous challenge. Currently, there
     are no targets in the scope. You can confirm that with the following command.
 
     ```
@@ -1309,7 +1310,7 @@ challenges:
     At the end of this challenge, you will have a target that you can connect to, but first, you must configure
     a few things.
 
-    The first thing you'll need to create is a *host catalog* named "HashiCups App" in the "HashiCups App" project
+    The first thing you'll need to create is a *host catalog* named "HashiCups Web App" in the "HashiCups Web App" project
     scope.
 
     ```
@@ -1331,7 +1332,7 @@ challenges:
       Updated Time:        Mon, 12 Jul 2021 16:48:28 UTC
       Version:             1
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the host catalog ID from the output and store it in an environment variable for later usage.
@@ -1370,7 +1371,7 @@ challenges:
       Updated Time:        Mon, 12 Jul 2021 20:37:34 UTC
       Version:             1
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the host ID from the output and store it in an environment variable for later usage.
@@ -1410,7 +1411,7 @@ challenges:
       Updated Time:        Mon, 12 Jul 2021 21:19:47 UTC
       Version:             1
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the host set ID from the output and store it in an environment variable for later usage.
@@ -1425,7 +1426,7 @@ challenges:
     echo "export SSH_HOST_SET_ID=$SSH_HOST_SET_ID" >> ~/.bashrc
     ```
 
-    Now you can add the hosts you created above to the host set.
+    Now you can add the host you created above to the host set.
 
     ```
     boundary host-sets add-hosts \
@@ -1446,7 +1447,7 @@ challenges:
       Updated Time:        Thu, 15 Jul 2021 19:59:46 UTC
       Version:             2
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     With the hosts added to the host set and the host catalog, it's time to define the target that you will ultimately
@@ -1476,7 +1477,7 @@ challenges:
       Updated Time:               Mon, 12 Jul 2021 20:46:41 UTC
       Version:                    1
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the target ID from the output and store it in an environment variable for later usage.
@@ -1513,7 +1514,7 @@ challenges:
       Updated Time:        Mon, 12 Jul 2021 20:46:31 UTC
       Version:             2
 
-    <...truncated..>
+    <...truncated...>
 
     Host IDs:
       hst_mnmBqpd9ky
@@ -1540,7 +1541,7 @@ challenges:
       Updated Time:               Wed, 30 Jun 2021 00:37:51 UTC
       Version:                    1
 
-    <...truncated..>
+    <...truncated...>
 
       Host Sets:
         Host Catalog ID:          hcst_jLHX9jl2kL
@@ -1609,8 +1610,6 @@ challenges:
 
     In this challenge, you'll create a group, one account for a DBA and one user for a DBA, as an example.
 
-    TODO: for now this uses the recovery-config, but I should fix the admin user to use that.
-
     ---
 
     This time, you'll start out by creating a group for the "HashiCups Engineering DBAs" team, under the HashiCups
@@ -1634,7 +1633,7 @@ challenges:
       Updated Time:        Tue, 20 Jul 2021 00:08:58 UTC
       Version:             1
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the DBA group ID from the output and store it in an environment variable for later usage.
@@ -1659,7 +1658,7 @@ challenges:
       -description "Role with read-only permission for Postgres."
     ```
 
-    Grab the DBA group ID from the output and store it in an environment variable for later usage.
+    Grab the DBA role ID from the output and store it in an environment variable for later usage.
 
     ```
     export PG_READ_ONLY_ROLE_ID=<PG_READ_ONLY_ROLE_ID>
@@ -1673,8 +1672,8 @@ challenges:
 
     ```
     boundary roles add-principals \
-      -id $DBA_GROUP_ID \
-      -principal $PG_READ_ONLY_ROLE_ID
+    	-id $PG_READ_ONLY_ROLE_ID \
+    	-principal $DBA_GROUP_ID
     ```
 
     ```
@@ -1713,7 +1712,7 @@ challenges:
         Parent Scope ID:   global
         Type:              org
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the DBA account ID from the output and store it in an environment variable for later usage.
@@ -1727,6 +1726,8 @@ challenges:
     ```
     echo "export DBA_USER_ACCOUNT_ID=$DBA_USER_ACCOUNT_ID" >> ~/.bashrc
     ```
+
+    Create the user.
 
     ```
     boundary users create \
@@ -1752,7 +1753,7 @@ challenges:
         Parent Scope ID:   global
         Type:              org
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the DBA user ID from the output and store it in an environment variable for later usage.
@@ -1771,7 +1772,6 @@ challenges:
 
     ```
     boundary users set-accounts \
-      -recovery-config /etc/boundary.d/recovery.hcl \
       -id $DBA_USER_ID \
       -account=$DBA_USER_ACCOUNT_ID
     ```
@@ -1793,14 +1793,13 @@ challenges:
         Parent Scope ID:   global
         Type:              org
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Add the user to the group.
 
     ```
     boundary groups add-members \
-      -recovery-config /etc/boundary.d/recovery.hcl \
       -id $DBA_GROUP_ID \
       -member=$DBA_USER_ID
     ```
@@ -1816,7 +1815,7 @@ challenges:
       Updated Time:        Mon, 19 Jul 2021 23:11:38 UTC
       Version:             2
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Finally, confirm that you can log in with the DBA user's credentials.
@@ -1895,7 +1894,7 @@ challenges:
       Updated Time:        Tue, 20 Jul 2021 22:54:57 UTC
       Version:             1
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the Postgres host ID from the output and store it in an environment variable for later usage.
@@ -1910,6 +1909,7 @@ challenges:
     echo "export POSTGRES_HOST_ID=$POSTGRES_HOST_ID" >> ~/.bashrc
     ```
 
+    Create a new host set named "test-postgres-host-set".
     ```
     boundary host-sets create static \
       -name "test-postgres-host-set" \
@@ -1930,7 +1930,7 @@ challenges:
       Updated Time:        Wed, 21 Jul 2021 00:55:41 UTC
       Version:             1
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the Postgres host set ID from the output and store it in an environment variable for later usage.
@@ -1945,6 +1945,7 @@ challenges:
     echo "export POSTGRES_HOST_SET_ID=$POSTGRES_HOST_SET_ID" >> ~/.bashrc
     ```
 
+    Add the Postgres host to the host set.
     ```
     boundary host-sets add-hosts \
       -id $POSTGRES_HOST_SET_ID \
@@ -1964,12 +1965,13 @@ challenges:
       Updated Time:        Wed, 21 Jul 2021 00:57:03 UTC
       Version:             2
 
-    <...truncated..>
+    <...truncated...>
     ```
 
+    Create a new target names "tests" for Postgres.
     ```
     boundary targets create tcp \
-      -name "tests" \
+      -name "postgres-test-targets" \
       -description "Test target" \
       -default-port 5432 \
       -scope-id $PROJECT_SCOPE_ID \
@@ -1983,14 +1985,14 @@ challenges:
       Created Time:               Wed, 21 Jul 2021 00:57:21 UTC
       Description:                Test target
       ID:                         ttcp_lUwoQUFcsi
-      Name:                       tests
+      Name:                       postgres-test-targets
       Session Connection Limit:   -1
       Session Max Seconds:        28800
       Type:                       tcp
       Updated Time:               Wed, 21 Jul 2021 00:57:21 UTC
       Version:                    1
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Grab the Postgres target ID from the output and store it in an environment variable for later usage.
@@ -2005,6 +2007,7 @@ challenges:
     echo "export POSTGRES_TARGET_ID=$POSTGRES_TARGET_ID" >> ~/.bashrc
     ```
 
+    Add the host set to the target.
     ```
     boundary targets add-host-sets \
       -id $POSTGRES_TARGET_ID \
@@ -2018,23 +2021,36 @@ challenges:
       Created Time:               Wed, 21 Jul 2021 00:57:21 UTC
       Description:                Test target
       ID:                         ttcp_lUwoQUFcsi
-      Name:                       tests
+      Name:                       postgres-test-targets
       Session Connection Limit:   -1
       Session Max Seconds:        28800
       Type:                       tcp
       Updated Time:               Wed, 21 Jul 2021 00:57:53 UTC
       Version:                    2
 
-    <...truncated..>
+    <...truncated...>
     ```
 
     Connect to it...
 
     ```
-    boundary connect postgres -target-id $POSTGRES_TARGET_ID
+    boundary connect postgres -target-id $POSTGRES_TARGET_ID -username=postgres
+    ```
+    and type the password, "postgres", when asked.
+
+    Example output:
+
+    ```
+    Password for user postgres:
+    psql (12.8 (Ubuntu 12.8-0ubuntu0.20.04.1), server 13.4 (Debian 13.4-1.pgdg100+1))
+    WARNING: psql major version 12, server major version 13.
+         Some psql features might not work.
+    Type "help" for help.
+
+    postgres=#
     ```
 
-    TODO: throwing an SSL error
+    Congratulations! You have successfully set up a new host, host set, and target for Postgres and connected to your Postgres database with Boundary.
   tabs:
   - title: Boundary Controller
     type: terminal
@@ -2052,7 +2068,7 @@ challenges:
   id: 6n8fgeuzipfy
   type: challenge
   title: Manage Sessions
-  teaser: Learn how you can manage Boundary sessions.
+  teaser: Learn to manage Boundary sessions.
   notes:
   - type: text
     contents: |-
@@ -2064,7 +2080,7 @@ challenges:
     TODO: log back in as the admin user.
 
     First, list your active sessions in the project scope. There should be none. Run the following in the
-    `Controller [Terminal 1]` tab.
+    `Boundary Controller [Terminal 1]` tab.
 
     ```
     boundary sessions list -scope-id $PROJECT_SCOPE_ID
@@ -2076,15 +2092,15 @@ challenges:
     No sessions found
     ```
 
-    Next, create you'll want to create a session in the `Controller [Terminal 1]` tab. Sessions are created whenever
+    Next, you'll want to create a session in the `Boundary Controller [Terminal 1]` tab. Sessions are created whenever
     a connection to a target is established, so you should establish an SSH connection to the worker node.
 
     ```
     boundary connect ssh -target-id $SSH_TARGET_ID
     ```
 
-    Once you have established your connection to the worker node in the `Controller [Terminal 1]`, switch to the
-    `Controller [Terminal 2]` tab and list the sessions again. You should now be able to see the session you created
+    Once you have established your connection to the worker node in the `Boundary Controller [Terminal 1]` tab, switch to the
+    `Boundary Controller [Terminal 2]` tab and list the sessions again. You should now be able to see the session you created
     when you connected to the worker node.
 
     ```
@@ -2125,7 +2141,7 @@ challenges:
     echo "export SESSION_ID=$SESSION_ID" >> ~/.bashrc
     ```
 
-    Note that the status of the sessions is `active`. You can inspect the session by looking it up with it's ID to
+    Note that the status of the session is `active`. You can inspect the session by looking it up with its ID to
     get more detailed information on the session. Try that now.
 
     ```
@@ -2346,4 +2362,4 @@ challenges:
     port: 9200
   difficulty: advanced
   timelimit: 600
-checksum: "11717550412821142608"
+checksum: "6004235857250934943"


### PR DESCRIPTION
I've made various modifications to assignments and notes and also fixed some commands in assighments and scripts.

# Roger's Comments

## Track Level
1. In the track description, I think "access to those targets" should be "access those targets".
2. The track logo does not exist. You can use https://storage.googleapis.com/instruqt-hashicorp-tracks/logo/boundary.png.

## Challenge Titles and Descriptions
1. In the "Manage Sessions" challenge, I would change "Learn how you can manage Boundary sessions" to "Learn to manage Boundary sessions" for better uniformity with other track descriptions that leave out "how you can" and simply use "to" instead.

## Challenge 1: getting-started-with-boundary
1. First note: change "allows you define" to "allows you to define" and change "to those principals" to "for those principals".
2. Second note: change "A scope can contain scopes" to "As scope can contain other scopes".
3. Second note: Should say "An organization inherits from the global scope".
4. Fourth note: highlight `boundary database init`.
5.  Second paragraph of assignment: change "specifid" to "specified".
6. I see your setup script for the controller does not run the `boundary users create` command that is given in https://www.boundaryproject.io/docs/installing/no-gen-resources#recovery-kms-workflow.  Why not?  I think because of what you said in the second paragraph of the challenge about using the KMS key as a global super user. But then, it is suprising that the doc uses the `boundary users create` command.
7. You should indicate which tab to run commands on. For instance, the `boundary scopes create` command has to be done on the "Boundary Controller" tab because the file /etc/boundary.d/recovery.hcl does not exist oon the Boundary worker.
8. I noticed that the Boundary UI was not yet being displayed in challenge 1.  I suggest removing the Boundary UI tab in challenge 1. In fact, you don't need the Boundary Worker tab in the first challenge either and don't have it or the UI in the second challenge.
9. First challenge setup, check and solve scripts look good.
10. First challenge check passed.

## Challenge 2: configure-auth-methods
1. Second challange check and solve scripts look good.
2. Second challenge check passed.

## Challenge 3: configure-your-first-roles
1. Second note: the claim that roles "manage the permissions given to principals (users and groups)" seems to contradict the previous note which said a princiapl can be a user, group, or project.
2. Third note: remove comma after "not logged in" and add "that they could use" before "to log in".
3. Second paragraph of assignment: change "will created" to "will create".
4. Fourth paragraph of assignment: change "To allow for users" to "To allow users".
5. The first command used to create the `global_anoun_listing` role has to include `-recovery-config /etc/boundary.d/recovery.hcl`
6. Users should be cautioned to grab the actual role ID and not the "Grant Scope ID" listed above it when exporting the role ID.  I accidentally did select the grant scope ID and then the following command to add grants failed because the value I was passing to `-id` with `$ORG_ANON_LISTING_ID` did not have permission. I also made a mistake exporting the org account id.
7. Check and Solve scripts look good.
8. Check passed.

## Challenge 4: configure-admin-accounts
1. Logging in fails, presumably because the new accounts have not yet been associated with roles and/or with internal Boundary users.
2. Check and solve scripts look good.
3. Check passed.

## Challenge 5: configure-admin-users
1. After fixing my exported org account ID, the last command worked.
2. check passed.

## Challenge 6: configure-admin-roles
1. In the assignment, there is a comment saying "And you're done configuring your admin users! You can now log in as the admin user." But I could actually login after the end of the previous challenge before creating the new roles in this challenge.  I did not try to do anything after logging in, but I did see a tree on the left with some objects.  Perhaps I would not have been allowed to expand them and explore their data?
2. Also, I wonder if it would be better to use different user names for the global and org-level admin users so that the name shown in the upper right corner of the Boundary UI would be different.
3. Comment in check script for global admin role creation has "org"; change to "global".
4. Check failed, saying "You did not create the org_admin role". You need to change the check-boundary-controller script to use this code:
```
ORG_ADMIN_ROLE_NAME=$(boundary roles list \
	-recovery-config /etc/boundary.d/recovery.hcl \
	-scope-id $ORG_SCOPE_ID \
	-format json | jq -r ".items[1].name")
```
You had `-scope-id global` and `-format json | jq -r ".items[2].name"`
5. In same check script, you also had issues with checking project scope admin role.  You need this:
```
PROJECT_ADMIN_ROLE_NAME=$(boundary roles list \
	-recovery-config /etc/boundary.d/recovery.hcl \
	-scope-id $PROJECT_SCOPE_ID \
	-format json | jq -r ".items[0].name")
```
You had `-scope-id $ORG_SCOPE_ID` and `".items[1].name"`.
You also needed to use `project_admin` in error message instead of `org_admin`.
6. After fixing the check script, the check passed.
7. I think you should explain Boundary tokens in this challenge.

## Challenge 7: configure-and-connect-to-your-first-target-with-ssh
1. In the first note, should "A host set belongs to one and only one host" be "A host set belongs to one and only one host catalog"?
2. In addition to mentioning being logged in, I suggest adding "and have exported a Boundary token".
3. In paragraph after first command, change "HashiCups App" to "HashiCups Web App". And two other occurences.
4. Also make that change in description of the host catalog in solve script.
5. Change "hosts" to "host" in paragraph before adding host to host set.
6. The `boundary targets read -id $SSH_TARGET_ID` command shows two host sources, but they seem identical.  Is this a Boundary bug?
7. For checking that the ssh has really worked (beyond seeing that the Linux prompt has changed), one could run `hostname`.
8. In both the check and solve scripts, change "test-ssh-host-set" to "test-machines".
9. Check script passed after fixing the above scripts.

## Challenge 8: configure-dba-group-accounts-users-and-roles
1. Can "TODO: for now this uses the recovery-config, but I should fix the admin user to use that." be removed? I don't think recovery-config is being used.
2. Second "Grab the DBA group ID from the output" should be "Grab the DBA role ID from the output".
3. Command for `boundary roles add-principals` failed. It needs to be like the one in solve script: so use:
```
boundary roles add-principals \
	-id $PG_READ_ONLY_ROLE_ID \
	-principal $DBA_GROUP_ID
```
instead of:
```
boundary roles add-principals \
  -id $DBA_GROUP_ID \
  -principal $PG_READ_ONLY_ROLE_ID
```
4. I find it confusing that you say "Grab the DBA account ID from the output" after creating the password and also that you use the variable DBA_USER_ACCOUNT_ID. But perhaps this is a Boundary issue since it seems the single command `boundary accounts create password` creates an account and a password for it. Note that the generated id starts with "acctpw" rather than with "acct". Perhaps the confusion is that there are two types of Boundary accounts: password and oidc.  So, since we are creating an account of type password, we end up with an id starting with "acctpw"?
5. Add "Create the user." before the command that does that.
6. Remove `-recovery-config /etc/boundary.d/recovery.hcl \` from commands `boundary users set-accounts` and `boundary groups add-members`.
7. Check script passed.
8. Should solve script do the `boundary authenticate password` command so that this is part of the test?
9. Somehow, my pushing of track after using Atom editor has messes up text. I fixed.

## Challenge 9: configure-and-connect-to-postgres-with-tcp
1. Add line about creating host-set
2. Add line about adding host to the host-set
3. Add line about creating the new target for Postrgres.
4. Add line about adding the host-set to the target.
5. The command to connect to postgres has to add `-username=postgres` so that the postgres user will be set to postgres instead of to root.
6. Add congratulations message at end of assignment.
7. Change "postgres-host" to "postgres" in check and solve scripts.
8. Change "tests" to "postgres-test-targets" when creating target for Postgres in track.yml.
9. Fix command to check host-set creation to this:
```
POSTGRES_HOST_SET_NAME=$(boundary host-sets list \
	-host-catalog-id $PROJECT_HOST_CATALOG_ID \
	-format json | jq -r ".items[1].name")
```
You had quotes around the entire command and -1 instead of 1 for the items index.
10. Change -1 to 1 in items index of the check for the postgres target.
11. In solve script, we can connect to postgres by exporting PGPASSWORD=postgres.

## Challenge 10: manage-sessions
1. Originally, when I first ran `boundary sessions list -scope-id $PROJECT_SCOPE_ID`, I had no sessions, but later I had several even though I have not run any more commands. Perhaps this was somehow caused by my running `instruqt track push` while running the track? But that seems unlikely. After stopping and restarting the track and skipping to this challenge, I found one terminated session.
2. Remove first "create" from "Next, create you'll want to create".
3. Fix "Controller [Terminal n]" tab names to start with "Boundary".
4. Change "sessions" to "session" in "Note that the status of the sessions is".
5. Change "it's" to "its" (possessive, not contraction).
6. Check script passed.

## Challenge 11: explore-the-admin-ui
1. Note 1: Text of third bullet seems fishy: "Security administrators gain monitor and managed the privileged sessions established with Boundary"
2. Also, final item in note seems extraneous since it summarizes what user will do in track.  Perhaps it is supposed to use past tense?
3. Text in second note also needs work.
4. There is no "Administration" role to select. Perhaps, you mean the global_admin role?
5. I don't see u_anon user listed in principals of global_admin role.
6. I also don't see "Login and Default Grants" role.
7. Not sure what "Generated ..." refers to.
8. Check script passed.
